### PR TITLE
Fix zero division in OneEuroFilter

### DIFF
--- a/kinect_moviment_reader
+++ b/kinect_moviment_reader
@@ -50,14 +50,17 @@ class OneEuroFilter:
     def filter(self, x):
         now = time.time()
         if self.last_time is None:
+            # Primeira amostra: inicializa estado e retorna valor bruto
             self.last_time = now
-        self.freq = 1.0 / (now - self.last_time)
-        self.last_time = now
-
-        if self.x_prev is None:
             self.x_prev = x
             self.dx_prev = 0.0 * x
             return x
+
+        dt = now - self.last_time
+        if dt <= 0:
+            dt = 1e-6  # evita divisão por zero ou negativa
+        self.freq = 1.0 / dt
+        self.last_time = now
 
         # Derivada do sinal
         dx = (x - self.x_prev) * self.freq


### PR DESCRIPTION
## Summary
- prevent zero division when OneEuroFilter receives the first value

## Testing
- `python3 - <<'PY'
import time, math
class OneEuroFilter:
    def __init__(self, freq, min_cutoff=1.0, beta=0.0, d_cutoff=1.0):
        self.freq = freq
        self.min_cutoff = min_cutoff
        self.beta = beta
        self.d_cutoff = d_cutoff
        self.last_time = None
        self.x_prev = None
        self.dx_prev = None
    def alpha(self, cutoff):
        te = 1.0 / self.freq
        tau = 1.0 / (2 * math.pi * cutoff)
        return 1.0 / (1.0 + tau / te)
    def filter(self, x):
        now = time.time()
        if self.last_time is None:
            self.last_time = now
            self.x_prev = x
            self.dx_prev = 0.0
            return x
        dt = now - self.last_time
        if dt <= 0:
            dt = 1e-6
        self.freq = 1.0 / dt
        self.last_time = now
        dx = (x - self.x_prev) * self.freq
        a_d = self.alpha(self.d_cutoff)
        dx_hat = a_d * dx + (1 - a_d) * self.dx_prev
        cutoff = self.min_cutoff + self.beta * abs(dx_hat)
        a = self.alpha(cutoff)
        x_hat = a * x + (1 - a) * self.x_prev
        self.x_prev = x_hat
        self.dx_prev = dx_hat
        return x_hat
f = OneEuroFilter(30)
print('first', f.filter(1.0))
time.sleep(0.01)
print('second', f.filter(1.1))
print('freq', f.freq)
PY

------
https://chatgpt.com/codex/tasks/task_b_68844b004a308321b5aeaacd873fb2cf